### PR TITLE
fix: disable hyphenation of generated pdf and should save resume data when editing all of fields

### DIFF
--- a/src/app/resume-editor/components/template/typography.tsx
+++ b/src/app/resume-editor/components/template/typography.tsx
@@ -24,6 +24,8 @@ Font.register({
     },
   ],
 });
+// https://github.com/diegomura/react-pdf/issues/1418
+Font.registerHyphenationCallback((word) => ["", word, ""]);
 
 const styles = StyleSheet.create({
   title: {

--- a/src/app/resume-editor/page.tsx
+++ b/src/app/resume-editor/page.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useLocalStorage } from "usehooks-ts";
 
 import { Resume } from "@/types/resume";
@@ -24,13 +24,12 @@ const ResumeEditorPage = () => {
   const formMethods = useForm<Resume>({
     defaultValues: value,
   });
-  const { watch, getValues } = formMethods;
-  const resume = watch();
+  const { control } = formMethods;
+  const resume = useWatch({ control }) as Resume;
 
-  const handleChange = () => {
-    const resume = getValues();
+  useEffect(() => {
     setValue(resume);
-  };
+  }, [resume, setValue]);
 
   // prevent hydration error caused by getting value from local storage on server side
   useEffect(() => {
@@ -50,7 +49,7 @@ const ResumeEditorPage = () => {
       <main>
         <FormProvider {...formMethods}>
           {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
-          <form id="resume-form" onChange={handleChange}>
+          <form id="resume-form">
             <div className="flex">
               <div className="w-1/2 p-12">
                 <ResumeForm />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


<!-- ## How Has This Been Tested? -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

-  disable hyphenation, let the words should be break
- Some fields use custom components that cannot trigger the `<form>` `onChange` event after being edited. Therefore, `useWatch()` is used instead to correctly retrieve the latest data.

## Screenshots (if appropriate):

<img width="444" alt="截圖 2024-11-17 凌晨12 02 43" src="https://github.com/user-attachments/assets/50e72b8b-d808-4392-9a3a-9cb603189fab">

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- ## Checklist: -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- - [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->