### PR TITLE
fix: pass null to format date range cause error

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,10 @@
+const path = require("path");
+
+const buildEslintCommand = (filenames) =>
+  `next lint --fix --file ${filenames
+    .map((f) => path.relative(process.cwd(), f))
+    .join(" --file ")}`;
+
+module.exports = {
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand],
+};

--- a/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
+++ b/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
@@ -51,7 +51,7 @@ const LabeledDatePickerField = ({
     <div className="space-y-2">
       <div className="flex justify-between">
         <div>{label}</div>
-        <div className="flex gap-1">
+        <div className="flex gap-1 items-center">
           <Switch checked={checked} onCheckedChange={handleCheckedChange} />
           {switchText}
         </div>

--- a/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
+++ b/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
@@ -9,7 +9,7 @@ interface LabeledDatePickerFieldProps {
   value: {
     from: string | null;
     to: string | null;
-  } | null;
+  };
   onChange: (value: { from: string | null; to: string | null }) => void;
 }
 
@@ -19,7 +19,7 @@ const LabeledDatePickerField = ({
   onChange,
   value,
 }: LabeledDatePickerFieldProps) => {
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState(() => value.to === null);
 
   const handleChangeFromMonth = useCallback(
     (date: Date) => {

--- a/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
+++ b/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
@@ -62,12 +62,14 @@ const LabeledDatePickerField = ({
           onMonthChange={handleChangeFromMonth}
           placeholder="From"
           value={value?.from ? new Date(value.from) : null}
+          className="flex-1"
         />
         {!checked && (
           <MonthPicker
             onMonthChange={handleChangeToMonth}
             placeholder="To"
             value={value?.to ? new Date(value.to) : null}
+            className="flex-1"
           />
         )}
       </div>

--- a/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
+++ b/src/app/resume-editor/components/form/labeled-date-picker-field.tsx
@@ -21,16 +21,6 @@ const LabeledDatePickerField = ({
 }: LabeledDatePickerFieldProps) => {
   const [checked, setChecked] = useState(false);
 
-  const handleCheckedChange = useCallback(
-    (checked: boolean) => {
-      if (checked) {
-        onChange?.({ from: value?.from ?? null, to: null });
-      }
-      setChecked(checked);
-    },
-    [onChange, value?.from]
-  );
-
   const handleChangeFromMonth = useCallback(
     (date: Date) => {
       onChange?.({ from: date.toISOString(), to: value?.to ?? null });
@@ -43,6 +33,18 @@ const LabeledDatePickerField = ({
       onChange?.({ from: value?.from ?? null, to: date.toISOString() });
     },
     [onChange, value?.from]
+  );
+
+  const handleCheckedChange = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        onChange?.({ from: value?.from ?? null, to: null });
+      } else {
+        handleChangeToMonth(new Date());
+      }
+      setChecked(checked);
+    },
+    [handleChangeToMonth, onChange, value?.from]
   );
 
   return (

--- a/src/app/resume-editor/components/template/education.tsx
+++ b/src/app/resume-editor/components/template/education.tsx
@@ -16,7 +16,7 @@ const Education = ({ educations }: { educations: EducationType[] }) => {
             {education.degree}
             {education.major && ` of ${education.major}`}, {education.school}
           </Text>
-          <SubText>{formatDateRange(education.timeline)}</SubText>
+          <SubText>{formatDateRange(education.timeline, "In school")}</SubText>
         </View>
       ))}
     </View>

--- a/src/app/resume-editor/components/template/employment-history.tsx
+++ b/src/app/resume-editor/components/template/employment-history.tsx
@@ -22,7 +22,7 @@ const EmploymentHistory = ({
                 <Text bold>
                   {jobTitle}, {company}
                 </Text>
-                <SubText>{formatDateRange(timeline)}</SubText>
+                <SubText>{formatDateRange(timeline, "Present")}</SubText>
               </View>
 
               {description.split(SPLIT_TEXT).map((item, index) => (

--- a/src/components/ui/month-picker.tsx
+++ b/src/components/ui/month-picker.tsx
@@ -134,12 +134,14 @@ export interface MonthPickerProps {
   onMonthChange?: (newMonth: Date) => void;
   placeholder?: string;
   value?: Date | null;
+  className?: string;
 }
 
 const MonthPicker: FC<MonthPickerProps> = ({
   onMonthChange,
   placeholder = "Pick a date",
   value,
+  className,
 }) => {
   const [date, setDate] = useState<Date | null | undefined>(null);
 
@@ -159,7 +161,8 @@ const MonthPicker: FC<MonthPickerProps> = ({
           variant={"outline"}
           className={cn(
             "w-[280px] justify-start text-left font-normal",
-            !date && "text-muted-foreground"
+            !date && "text-muted-foreground",
+            className
           )}
         >
           <FaCalendar className="mr-2 size-4" />

--- a/src/lib/formatDateRange.ts
+++ b/src/lib/formatDateRange.ts
@@ -1,22 +1,25 @@
-import { format, parseISO, isValid } from "date-fns";
+import { format, parseISO } from "date-fns";
 
 interface DateRange {
-  from: string;
-  to: string;
+  from: string | null;
+  to: string | null;
 }
 
-const formatDateRange = ({ from, to }: DateRange): string => {
-  const fromDate = parseISO(from);
-  const toDate = parseISO(to);
+const formatDate = (date: string) => {
+  const dateFormatted = format(parseISO(date), "MMMM yyyy").toUpperCase();
 
-  if (!isValid(fromDate) || !isValid(toDate)) {
-    return "";
-  }
+  return dateFormatted;
+};
 
-  const fromFormatted = format(fromDate, "MMMM yyyy").toUpperCase();
-  const toFormatted = format(toDate, "MMMM yyyy").toUpperCase();
+const formatDateRange = (
+  timeline: DateRange,
+  placeholder: string
+): string => {
+  const { from, to } = timeline;
+  const fromDate = from ? formatDate(from) : "";
+  const toDate = to ? formatDate(to) : placeholder;
 
-  return `${fromFormatted} — ${toFormatted}`;
+  return `${fromDate} — ${toDate}`;
 };
 
 export default formatDateRange;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

<!-- ## How Has This Been Tested? -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Fix error caused by passing null to format date range
- Adjust styles of the `labeled-date-picker-field` component
- Set the field to the current date after unchecking
- Automatically set checked to true when the default value of to is null

## Screenshots (if appropriate):

<img width="337" alt="截圖 2024-11-17 中午12 34 43" src="https://github.com/user-attachments/assets/18a334ac-ed05-47ac-ad66-632849b1326a">

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- ## Checklist: -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- - [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->